### PR TITLE
fix(gvisor): make sure WriteNotify does not hang

### DIFF
--- a/gvisor.go
+++ b/gvisor.go
@@ -174,7 +174,10 @@ func (gvs *gvisorStack) StackClosed() <-chan any {
 // WriteNotify implements channel.Notification. GVisor will call this
 // callback function everytime there's a new readable packet.
 func (gvs *gvisorStack) WriteNotify() {
-	gvs.incomingPacket <- true
+	select {
+	case gvs.incomingPacket <- true:
+	case <-gvs.closed:
+	}
 }
 
 // WriteFrame implements NIC


### PR DESCRIPTION
To this end, we need to avoid writing into the notification channel once the stack has been closed.