### PR TITLE
fix(gvisor): buffered channel for write notifications

### DIFF
--- a/gvisor.go
+++ b/gvisor.go
@@ -82,7 +82,7 @@ func newGVisorStack(logger Logger, A netip.Addr, MTU uint32) (*gvisorStack, erro
 		endpoint:       channel.New(1024, MTU, ""),
 		name:           name,
 		ipAddress:      A,
-		incomingPacket: make(chan any),
+		incomingPacket: make(chan any, 1024),
 		logger:         logger,
 		stack:          stack.New(stackOptions),
 	}


### PR DESCRIPTION
Lacking precise performance data, it seems wiser to have the write notification be as large as the outstanding packets channel we construct for gvisor itself. It's a better default.