### PR TITLE
fix: decouple PLR and packet dropping

### DIFF
--- a/dpidrop.go
+++ b/dpidrop.go
@@ -44,8 +44,8 @@ func (r *DPIDropTrafficForServerEndpoint) Filter(
 	)
 	policy := &DPIPolicy{
 		Delay: 0,
-		Flags: 0,
-		PLR:   1.0, // we should always drop
+		Flags: FrameFlagDrop,
+		PLR:   0,
 	}
 	return policy, true
 }
@@ -98,8 +98,8 @@ func (r *DPIDropTrafficForTLSSNI) Filter(
 	)
 	policy := &DPIPolicy{
 		Delay: 0,
-		Flags: 0,
-		PLR:   1.0, // we should always drop
+		Flags: FrameFlagDrop,
+		PLR:   0,
 	}
 	return policy, true
 }

--- a/model.go
+++ b/model.go
@@ -16,6 +16,11 @@ const (
 	// FrameFlagRST tells a router it should reflect back
 	// a forged segment that contains the RST flag.
 	FrameFlagRST = 1 << iota
+
+	// FrameFlagDrop tells the link that the frame should be
+	// dropped rather than forwarded, to emulate a loss occurring
+	// on the link while the frame was in flight.
+	FrameFlagDrop
 )
 
 // Frame contains an IPv4 or IPv6 packet.


### PR DESCRIPTION
By having a dedicated flag, we can separate dropping a single packet from imposing a specific extra packet PLR.

This change simplifies designing algorithms for links.