### PR TITLE
fix(calibrate): produce actionable CSV entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+*.csv
 *.pcap
+.DS_Store
+/calibrate

--- a/cmd/calibrate/main.go
+++ b/cmd/calibrate/main.go
@@ -17,6 +17,8 @@ import (
 
 func main() {
 	// parse command line flags
+	timedPrefix := "calibration_" + time.Now().Format("20060102T150405Z")
+	pcapFilePrefix := flag.String("pcap-file-prefix", timedPrefix, "prefix of the PCAP files")
 	plr := flag.Float64("plr", 0, "right-to-left packet loss rate")
 	rtt := flag.Duration("rtt", 0, "RTT delay")
 	star := flag.Bool("star", false, "force using a star network topology")
@@ -39,12 +41,13 @@ func main() {
 
 	// characteristics of the client link
 	clientLink := &netem.LinkConfig{
-		LeftNICWrapper:   nil,
+		DPIEngine:        nil,
+		LeftNICWrapper:   netem.NewPCAPDumper(*pcapFilePrefix+"_client.pcap", log.Log),
 		LeftToRightDelay: *rtt / 2,
 		LeftToRightPLR:   0,
+		RightNICWrapper:  netem.NewPCAPDumper(*pcapFilePrefix+"_server.pcap", log.Log),
 		RightToLeftDelay: *rtt / 2,
 		RightToLeftPLR:   *plr,
-		RightNICWrapper:  netem.NewPCAPDumper("calibration.pcap", log.Log),
 	}
 
 	// create the required topology
@@ -73,7 +76,6 @@ func main() {
 
 	// wait for server to be listening
 	listener := <-ready
-	defer listener.Close()
 
 	// run client in the background and measure speed
 	clientErrch := make(chan error, 1)
@@ -91,7 +93,7 @@ func main() {
 	// loop and emit performance samples
 	fmt.Printf("%s\n", netem.NDT0CSVHeader)
 	for sample := range perfch {
-		fmt.Printf("%s\n", sample.CSVRecord())
+		fmt.Printf("%s\n", sample.CSVRecord(*pcapFilePrefix, *rtt, *plr))
 	}
 
 	// obtain the error returned by the client
@@ -99,6 +101,9 @@ func main() {
 	if errClient != nil {
 		log.Warnf("RunNDT0Client: %s", errClient.Error())
 	}
+
+	// explicitly close the listener because it may be stuck
+	listener.Close()
 
 	// obtain the error returned by the server
 	errServer := <-serverErrch

--- a/cmd/throttle/main.go
+++ b/cmd/throttle/main.go
@@ -98,7 +98,7 @@ func main() {
 	// loop and emit performance samples
 	fmt.Printf("%s\n", netem.NDT0CSVHeader)
 	for sample := range perfch {
-		fmt.Printf("%s\n", sample.CSVRecord())
+		fmt.Printf("%s\n", sample.CSVRecord("", 0, 0))
 	}
 
 	// obtain the error returned by the client

--- a/integration_test.go
+++ b/integration_test.go
@@ -149,7 +149,7 @@ func TestLinkPLR(t *testing.T) {
 	var speeds []float64
 	for p := range perfch {
 		speeds = append(speeds, p.AvgSpeedMbps())
-		t.Log(p.CSVRecord())
+		t.Log(p.CSVRecord("", 0, 0))
 	}
 
 	// make sure we have collected samples
@@ -518,7 +518,7 @@ func TestDPITCPThrottleForSNI(t *testing.T) {
 			var speeds []float64
 			for p := range perfch {
 				speeds = append(speeds, p.AvgSpeedMbps())
-				t.Log(p.CSVRecord())
+				t.Log(p.CSVRecord("", 0, 0))
 			}
 
 			// make sure we have collected samples
@@ -667,7 +667,7 @@ func TestDPITCPResetForSNI(t *testing.T) {
 			// drain the performance channel
 			var count int
 			for p := range perfch {
-				t.Log(p.CSVRecord())
+				t.Log(p.CSVRecord("", 0, 0))
 				count++
 			}
 
@@ -818,7 +818,7 @@ func TestDPITCPDropForSNI(t *testing.T) {
 			// drain the performance channel
 			var count int
 			for p := range perfch {
-				t.Log(p.CSVRecord())
+				t.Log(p.CSVRecord("", 0, 0))
 				count++
 			}
 
@@ -973,7 +973,7 @@ func TestDPITCPDropForEndpoint(t *testing.T) {
 			// drain the performance channel
 			var count int
 			for p := range perfch {
-				t.Log(p.CSVRecord())
+				t.Log(p.CSVRecord("", 0, 0))
 				count++
 			}
 


### PR DESCRIPTION
We need to include in each row:

1. the prefix of the PCAP files we're capturing;

2. the imposed RTT;

3. the imposed packet loss rate.

We need to also capture packets at the client, because otherwise we cannot observe whether we're producing any traffic bursts.

We need to refactor the client measurement algorithm such that we include a final sample with the overall average goodput. To this end, we include a boolean telling us whether an individual CSV row is an interim or a final sample. Data consumers could then grep for that flag to only collect the final sample.

While there:

1. ignore more files in `.gitignore`;

2. make sure `calibrate` is not stuck in accept by explicitly closing the listener.