### PR TITLE
chore: split racedetector and coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - run: go test -race -v -coverprofile=netem.cov .
+      - run: go test -coverprofile=netem.cov .
 
       - uses: shogo82148/actions-goveralls@v1
         with:

--- a/.github/workflows/racedetector.yml
+++ b/.github/workflows/racedetector.yml
@@ -1,0 +1,18 @@
+name: racedetector
+on:
+  pull_request:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  coverage:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "1.19"
+
+      - uses: actions/checkout@v3
+
+      - run: go test -race .

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Netem
 
-[![alltests](https://github.com/ooni/netem/actions/workflows/alltests.yml/badge.svg)](https://github.com/ooni/netem/actions/workflows/alltests.yml) [![GoDoc](https://pkg.go.dev/badge/github.com/ooni/netem/)](https://pkg.go.dev/github.com/ooni/netem/v3) [![Coverage Status](https://coveralls.io/repos/github/ooni/netem/badge.svg?branch=main)](https://coveralls.io/github/ooni/netem?branch=main) [![Slack](https://slack.openobservatory.org/badge.svg)](https://slack.openobservatory.org/)
+[![alltests](https://github.com/ooni/netem/actions/workflows/alltests.yml/badge.svg)](https://github.com/ooni/netem/actions/workflows/alltests.yml) [![GoDoc](https://pkg.go.dev/badge/github.com/ooni/netem/)](https://pkg.go.dev/github.com/ooni/netem) [![Coverage Status](https://coveralls.io/repos/github/ooni/netem/badge.svg?branch=main)](https://coveralls.io/github/ooni/netem?branch=main) [![Slack](https://slack.openobservatory.org/badge.svg)](https://slack.openobservatory.org/)
 
 Netem allows writing integration tests in Go where networking code
 uses [Gvisor](https://gvisor.dev/)-based networking. Netem also


### PR DESCRIPTION
I think it's better to split them. Eventually coverage will be based on unit tests while race detector should also run the integration tests, because we want to perform data race detection beyond unit tests.