### PR TITLE
fix(throttling): increase delay per flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ go get -u -v -d github.com/ooni/netem
 
 This command will download netem and update your `go.mod` and `go.sum`.
 
+You _probably_ also want to manually force using the [Gvisor](https://gvisor.dev/)
+version we're using in this library with:
+
+```
+go get -u -v -d gvisor.dev/gvisor@COMMIT_HASH
+```
+
+because future [Gvisor](https://gvisor.dev/) versions may not build
+with the version of Go we're using here.
+
 ## Running tests
 
 ```bash

--- a/dpithrottle.go
+++ b/dpithrottle.go
@@ -4,12 +4,19 @@ package netem
 // DPI: rules to throttle flows
 //
 
-import "github.com/google/gopacket/layers"
+import (
+	"time"
+
+	"github.com/google/gopacket/layers"
+)
 
 // DPIThrottleTrafficForTLSSNI is a [DPIRule] that throttles traffic
 // after it sees a given TLS SNI. The zero value is not valid. Make sure
 // you initialize all fields marked as MANDATORY.
 type DPIThrottleTrafficForTLSSNI struct {
+	// Delay is the OPTIONAL extra delay to add to the flow.
+	Delay time.Duration
+
 	// Logger is the MANDATORY logger to use.
 	Logger Logger
 
@@ -56,7 +63,7 @@ func (r *DPIThrottleTrafficForTLSSNI) Filter(
 		sni,
 	)
 	policy := &DPIPolicy{
-		Delay: 0,
+		Delay: r.Delay,
 		Flags: 0,
 		PLR:   r.PLR,
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -479,14 +479,15 @@ func TestDPITCPThrottleForSNI(t *testing.T) {
 			// throttle the offending SNI to have high latency and hig losses
 			dpiEngine := netem.NewDPIEngine(log.Log)
 			dpiEngine.AddRule(&netem.DPIThrottleTrafficForTLSSNI{
+				Delay:  10 * time.Millisecond,
 				Logger: log.Log,
 				PLR:    0.1,
 				SNI:    tc.offendingSNI,
 			})
 			lc := &netem.LinkConfig{
 				DPIEngine:        dpiEngine,
-				LeftToRightDelay: 10 * time.Millisecond,
-				RightToLeftDelay: 10 * time.Millisecond,
+				LeftToRightDelay: 100 * time.Microsecond,
+				RightToLeftDelay: 100 * time.Microsecond,
 			}
 
 			// create a point-to-point topology, which consists of a single

--- a/linkfwdfull.go
+++ b/linkfwdfull.go
@@ -134,11 +134,15 @@ func LinkFwdFull(cfg *LinkFwdConfig) {
 				// compute baseline frame PLR
 				framePLR := cfg.PLR
 
+				// allow the DPI to increase a flow's delay
+				var flowDelay time.Duration
+
 				// run the DPI engine, if configured
 				policy, match := cfg.maybeInspectWithDPI(frame.Payload)
 				if match {
 					frame.Flags |= policy.Flags
 					framePLR += policy.PLR
+					flowDelay += policy.Delay
 				}
 
 				// check whether we need to drop this frame (we will drop it
@@ -148,7 +152,7 @@ func LinkFwdFull(cfg *LinkFwdConfig) {
 				}
 
 				// create frame RX deadline
-				d := time.Now().Add(cfg.OneWayDelay + jitter)
+				d := time.Now().Add(cfg.OneWayDelay + jitter + flowDelay)
 				frame.Deadline = d
 
 				// congratulations, the frame is now in flight 🚀


### PR DESCRIPTION
So, we can model a link with more losses and more delay for the throttled flow, which further separates the expected peformance for throttled and nonthrottled.

While there, add note about pinning gvisor, which seems to live at HEAD much more than we do.