### PR TITLE
fix(dnsserver): make sure CNAME is canonical

### DIFF
--- a/dnsserver.go
+++ b/dnsserver.go
@@ -107,7 +107,7 @@ func (dc *DNSConfig) AddRecord(domain string, cname string, addrs ...string) err
 	dc.mu.Lock()
 	dc.r[dns.CanonicalName(domain)] = &dnsRecord{
 		A:     a,
-		CNAME: cname,
+		CNAME: dns.CanonicalName(cname),
 	}
 	dc.mu.Unlock()
 	return nil

--- a/dnsserver.go
+++ b/dnsserver.go
@@ -104,10 +104,13 @@ func (dc *DNSConfig) AddRecord(domain string, cname string, addrs ...string) err
 		}
 		a = append(a, ip)
 	}
+	if cname != "" {
+		cname = dns.CanonicalName(cname)
+	}
 	dc.mu.Lock()
 	dc.r[dns.CanonicalName(domain)] = &dnsRecord{
 		A:     a,
-		CNAME: dns.CanonicalName(cname),
+		CNAME: cname,
 	}
 	dc.mu.Unlock()
 	return nil


### PR DESCRIPTION
Otherwise, if the user does not provide a canonical CNAME, the server code will panic at runtime.