### PR TITLE
[API CHANGE] feat: implement DNS spoofing

### DIFF
--- a/dissect.go
+++ b/dissect.go
@@ -330,7 +330,7 @@ func reflectDissectedTCPSegmentWithRSTFlag(packet *DissectedPacket) ([]byte, err
 
 // reflectDissectedUDPDatagramWithPayload assumes that packet is an IPv4 packet
 // containing a UDP datagram, and constructs a new serialized packet where
-// we reflect incoming fields with the given payload.
+// we reflect the incoming fields and set the given payload.
 func reflectDissectedUDPDatagramWithPayload(packet *DissectedPacket, rawPayload []byte) ([]byte, error) {
 	var (
 		ipv4 *layers.IPv4

--- a/dpidrop.go
+++ b/dpidrop.go
@@ -43,9 +43,10 @@ func (r *DPIDropTrafficForServerEndpoint) Filter(
 		r.ServerProtocol,
 	)
 	policy := &DPIPolicy{
-		Delay: 0,
-		Flags: FrameFlagDrop,
-		PLR:   0,
+		Delay:   0,
+		Flags:   FrameFlagDrop,
+		PLR:     0,
+		Spoofed: nil,
 	}
 	return policy, true
 }
@@ -97,9 +98,10 @@ func (r *DPIDropTrafficForTLSSNI) Filter(
 		sni,
 	)
 	policy := &DPIPolicy{
-		Delay: 0,
-		Flags: FrameFlagDrop,
-		PLR:   0,
+		Delay:   0,
+		Flags:   FrameFlagDrop,
+		PLR:     0,
+		Spoofed: nil,
 	}
 	return policy, true
 }

--- a/dpiengine.go
+++ b/dpiengine.go
@@ -35,6 +35,11 @@ type DPIPolicy struct {
 
 	// PLR is the extra PLR to add to the packet.
 	PLR float64
+
+	// Spoofed contains the spoofed frames to attach to
+	// the [Frame] so that we emit spoofed packets in the
+	// router when the frame is being processed.
+	Spoofed [][]byte
 }
 
 // DPIRule is a deep packet inspection rule.

--- a/dpithrottle.go
+++ b/dpithrottle.go
@@ -63,9 +63,10 @@ func (r *DPIThrottleTrafficForTLSSNI) Filter(
 		sni,
 	)
 	policy := &DPIPolicy{
-		Delay: r.Delay,
-		Flags: 0,
-		PLR:   r.PLR,
+		Delay:   r.Delay,
+		Flags:   0,
+		PLR:     r.PLR,
+		Spoofed: nil,
 	}
 	return policy, true
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -797,7 +797,7 @@ func TestDPISpoofDNSResponse(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Log("check for DNS response spoof", tc.name)
 
-			// make sure that the offending SNI causes RST
+			// make sure that the offending domain causes DNS spoofing
 			dpiEngine := netem.NewDPIEngine(log.Log)
 			dpiEngine.AddRule(&netem.DPISpoofDNSResponse{
 				Addresses: tc.spoofedAddrs,

--- a/linkfwdfull.go
+++ b/linkfwdfull.go
@@ -141,6 +141,7 @@ func LinkFwdFull(cfg *LinkFwdConfig) {
 				policy, match := cfg.maybeInspectWithDPI(frame.Payload)
 				if match {
 					frame.Flags |= policy.Flags
+					frame.Spoofed = policy.Spoofed
 					framePLR += policy.PLR
 					flowDelay += policy.Delay
 				}

--- a/model.go
+++ b/model.go
@@ -13,9 +13,9 @@ import (
 )
 
 const (
-	// FrameFlagRST tells a router it should reflect back
-	// a forged segment that contains the RST flag.
-	FrameFlagRST = 1 << iota
+	// FrameFlagSpoof tells the router it should send the
+	// spoofed frames inside the [Frame] Spoofed field.
+	FrameFlagSpoof = 1 << iota
 
 	// FrameFlagDrop tells the link that the frame should be
 	// dropped rather than forwarded, to emulate a loss occurring
@@ -34,6 +34,11 @@ type Frame struct {
 
 	// Payload contains the packet payload.
 	Payload []byte
+
+	// Spoofeed contains zero of more packets that the router should
+	// spoof when processing this packet. We honor this field iff the
+	// FrameFlagSpoof flag is set in the Flags field.
+	Spoofed [][]byte
 }
 
 // NewFrame constructs a [Frame] for the given [Payload].
@@ -42,6 +47,7 @@ func NewFrame(payload []byte) *Frame {
 		Deadline: time.Now(),
 		Flags:    0,
 		Payload:  payload,
+		Spoofed:  nil,
 	}
 }
 
@@ -52,6 +58,7 @@ func (f *Frame) ShallowCopy() *Frame {
 		Deadline: f.Deadline,
 		Flags:    f.Flags,
 		Payload:  f.Payload,
+		Spoofed:  f.Spoofed,
 	}
 }
 

--- a/model.go
+++ b/model.go
@@ -35,7 +35,7 @@ type Frame struct {
 	// Payload contains the packet payload.
 	Payload []byte
 
-	// Spoofeed contains zero of more packets that the router should
+	// Spoofed contains zero or more packets that the router should
 	// spoof when processing this packet. We honor this field iff the
 	// FrameFlagSpoof flag is set in the Flags field.
 	Spoofed [][]byte


### PR DESCRIPTION
This diff implements DNS spoofing. To this end, we restructure how RST injection works first. We drop the `FrameFlagRST` flag, which implemented RST injection, and we replace it with `FrameFlagSpoof`. We introduce in `DPIPolicy` and `Frame` the possibility of indicating spoofed IP packets. A DPI rule that matches and wants to spoof packets will need to set the `FrameFlagSpoof` and prepare the packets to spoof. The router will honor the `FrameFlagSpoof` and spoof all indicates packets before forwarding the `Frame` with the `FrameFlagSpoof` set.

Once we have implemented this change, we write a new DPI rule that spoofs DNS responses when it sees a query containing an offending domain name. The implementation just uses `FrameFlagSpoof`.

While testing this diff, we realized that all rules using `FrameFlagSpoof` require some delay in the router<->server path to ensure that the spoofed packets arrive earlier. Hence, we updated the documentation and the integration tests to make sure this need to add extra delay on the router<->server path is documented and reflected by tests.

This diff CHANGES THE PREVIOUS API because the `FrameFlagRST` has been replaced by `FrameFlagSpoof`.