### PR TITLE
feat: implement missing DPI rules

### DIFF
--- a/dpiblock.go
+++ b/dpiblock.go
@@ -336,7 +336,7 @@ func (r *DPICloseConnectionForTLSSNI) Filter(
 		return nil, false
 	}
 
-	// tell the user we're asking the router to FIN the flow.
+	// tell the user we're asking the router to FIN|ACK the flow.
 	r.Logger.Infof(
 		"netem: dpi: asking to send FIN|ACK to flow %s:%d %s:%d/%s because SNI==%s",
 		packet.SourceIPAddress(),
@@ -481,7 +481,7 @@ func (r *DPICloseConnectionForString) Filter(
 		return nil, false
 	}
 
-	// tell the user we're asking the router to FIN the flow.
+	// tell the user we're asking the router to FIN|ACK the flow.
 	r.Logger.Infof(
 		"netem: dpi: asking to send FIN|ACK to flow %s:%d %s:%d/%s because it contains %s",
 		packet.SourceIPAddress(),
@@ -516,8 +516,9 @@ func (r *DPICloseConnectionForString) Filter(
 //
 // Note: this rule requires the blockpage to be very small.
 type DPISpoofBlockpageForString struct {
-	// Blockpage is the MANDATORY blockpage content.
-	Blockpage []byte
+	// HTTPResponse is the MANDATORY blockpage content prefix with HTTP
+	// headers (use DPIFormatHTTPResponse to produce this field).
+	HTTPResponse []byte
 
 	// Logger is the MANDATORY logger.
 	Logger Logger
@@ -569,12 +570,12 @@ func (r *DPISpoofBlockpageForString) Filter(
 	}
 	reflected.tcp.ACK = true
 	reflected.tcp.FIN = true
-	spoofed, err := reflected.serialize(gopacket.Payload(r.Blockpage))
+	spoofed, err := reflected.serialize(gopacket.Payload(r.HTTPResponse))
 	if err != nil {
 		return nil, false
 	}
 
-	// tell the user we're asking the router to FIN the flow.
+	// tell the user we're asking the router to spoof a blockpage.
 	r.Logger.Infof(
 		"netem: dpi: spoofing blockpage to flow %s:%d %s:%d/%s because it contains %s",
 		packet.SourceIPAddress(),

--- a/dpiblock.go
+++ b/dpiblock.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"net"
 
+	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/miekg/dns"
 )
@@ -392,7 +393,6 @@ func (r *DPICloseConnectionForServerEndpoint) Filter(
 	spoofed, err := reflectDissectedTCPSegmentWithSetter(packet, func(tcp *layers.TCP) {
 		tcp.RST = true
 		tcp.ACK = true
-		tcp.Ack += 1 // the SYN consumes one sequence number
 	})
 
 	// make sure we could spoof the packet
@@ -419,4 +419,186 @@ func (r *DPICloseConnectionForServerEndpoint) Filter(
 	}
 
 	return policy, true
+}
+
+// DPICloseConnectionForString is a [DPIRule] that spoofs a FIN|ACK TCP segment
+// after it sees a given string in the payload. The zero value is invalid; please, fill
+// all the fields marked as MANDATORY.
+//
+// Note: this rule assumes that there is a router in the path that
+// can generate a spoofed RST segment. If there is no router in the
+// path, no RST segment will ever be generated.
+//
+// Note: this rule relies on a race condition. For consistent results
+// you MUST set some delay in the router<->server link.
+type DPICloseConnectionForString struct {
+	// Logger is the MANDATORY logger.
+	Logger Logger
+
+	// ServerIPAddress is the MANDATORY server endpoint IP address.
+	ServerIPAddress string
+
+	// ServerPort is the MANDATORY server endpoint port.
+	ServerPort uint16
+
+	// SNI is the MANDATORY offending string.
+	String string
+}
+
+var _ DPIRule = &DPICloseConnectionForString{}
+
+// Filter implements DPIRule
+func (r *DPICloseConnectionForString) Filter(
+	direction DPIDirection, packet *DissectedPacket) (*DPIPolicy, bool) {
+	// short circuit for the return path
+	if direction != DPIDirectionClientToServer {
+		return nil, false
+	}
+
+	// short circuit for UDP packets
+	if packet.TransportProtocol() != layers.IPProtocolTCP {
+		return nil, false
+	}
+
+	// make sure the remote server is filtered
+	if !packet.MatchesDestination(layers.IPProtocolTCP, r.ServerIPAddress, r.ServerPort) {
+		return nil, false
+	}
+
+	// short circuit in case of misconfiguration
+	if r.String == "" {
+		return nil, false
+	}
+
+	// if the packet is not offending, accept it
+	if !bytes.Contains(packet.TCP.Payload, []byte(r.String)) {
+		return nil, false
+	}
+
+	// generate the frame to spoof
+	spoofed, err := reflectDissectedTCPSegmentWithFINACKFlag(packet)
+	if err != nil {
+		return nil, false
+	}
+
+	// tell the user we're asking the router to FIN the flow.
+	r.Logger.Infof(
+		"netem: dpi: asking to send FIN|ACK to flow %s:%d %s:%d/%s because it contains %s",
+		packet.SourceIPAddress(),
+		packet.SourcePort(),
+		packet.DestinationIPAddress(),
+		packet.DestinationPort(),
+		packet.TransportProtocol(),
+		r.String,
+	)
+
+	// make sure the router knows it should spoof
+	policy := &DPIPolicy{
+		Delay:   0,
+		Flags:   FrameFlagSpoof,
+		PLR:     0,
+		Spoofed: [][]byte{spoofed},
+	}
+
+	return policy, true
+}
+
+// DPISpoofBlockpageForString is a [DPIRule] that spoofs a blockpage
+// after it sees a given string in the payload. The zero value is invalid; please, fill
+// all the fields marked as MANDATORY.
+//
+// Note: this rule assumes that there is a router in the path that
+// can generate a spoofed RST segment. If there is no router in the
+// path, no RST segment will ever be generated.
+//
+// Note: this rule relies on a race condition. For consistent results
+// you MUST set some delay in the router<->server link.
+//
+// Note: this rule requires the blockpage to be very small.
+type DPISpoofBlockpageForString struct {
+	// Blockpage is the MANDATORY blockpage content.
+	Blockpage []byte
+
+	// Logger is the MANDATORY logger.
+	Logger Logger
+
+	// ServerIPAddress is the MANDATORY server endpoint IP address.
+	ServerIPAddress string
+
+	// ServerPort is the MANDATORY server endpoint port.
+	ServerPort uint16
+
+	// SNI is the MANDATORY offending string.
+	String string
+}
+
+var _ DPIRule = &DPISpoofBlockpageForString{}
+
+// Filter implements DPIRule
+func (r *DPISpoofBlockpageForString) Filter(
+	direction DPIDirection, packet *DissectedPacket) (*DPIPolicy, bool) {
+	// short circuit for the return path
+	if direction != DPIDirectionClientToServer {
+		return nil, false
+	}
+
+	// short circuit for UDP packets
+	if packet.TransportProtocol() != layers.IPProtocolTCP {
+		return nil, false
+	}
+
+	// make sure the remote server is filtered
+	if !packet.MatchesDestination(layers.IPProtocolTCP, r.ServerIPAddress, r.ServerPort) {
+		return nil, false
+	}
+
+	// short circuit in case of misconfiguration
+	if r.String == "" {
+		return nil, false
+	}
+
+	// if the packet is not offending, accept it
+	if !bytes.Contains(packet.TCP.Payload, []byte(r.String)) {
+		return nil, false
+	}
+
+	// generate the frame to spoof
+	reflected, err := packet.reflectSegment()
+	if err != nil {
+		return nil, false
+	}
+	reflected.tcp.ACK = true
+	reflected.tcp.FIN = true
+	spoofed, err := reflected.serialize(gopacket.Payload(r.Blockpage))
+	if err != nil {
+		return nil, false
+	}
+
+	// tell the user we're asking the router to FIN the flow.
+	r.Logger.Infof(
+		"netem: dpi: spoofing blockpage to flow %s:%d %s:%d/%s because it contains %s",
+		packet.SourceIPAddress(),
+		packet.SourcePort(),
+		packet.DestinationIPAddress(),
+		packet.DestinationPort(),
+		packet.TransportProtocol(),
+		r.String,
+	)
+
+	// make sure the router knows it should spoof
+	policy := &DPIPolicy{
+		Delay:   0,
+		Flags:   FrameFlagSpoof,
+		PLR:     0,
+		Spoofed: [][]byte{spoofed},
+	}
+
+	return policy, true
+}
+
+// DPIFormatHTTPResponse formats an HTTP response for a blockpage.
+func DPIFormatHTTPResponse(blockpage []byte) (output []byte) {
+	output = append(output, []byte("HTTP/1.0 200 OK\r\n\r\n")...)
+	output = append(output, blockpage...)
+	return
 }

--- a/dpidrop.go
+++ b/dpidrop.go
@@ -4,7 +4,11 @@ package netem
 // DPI: rules to drop packets
 //
 
-import "github.com/google/gopacket/layers"
+import (
+	"bytes"
+
+	"github.com/google/gopacket/layers"
+)
 
 // DPIDropTrafficForServerEndpoint is a [DPIRule] that drops all
 // the traffic towards a given server endpoint. The zero value is invalid;
@@ -96,6 +100,71 @@ func (r *DPIDropTrafficForTLSSNI) Filter(
 		packet.DestinationPort(),
 		packet.TransportProtocol(),
 		sni,
+	)
+	policy := &DPIPolicy{
+		Delay:   0,
+		Flags:   FrameFlagDrop,
+		PLR:     0,
+		Spoofed: nil,
+	}
+	return policy, true
+}
+
+// DPIDropTrafficForString is a [DPIRule] that drops all
+// the traffic after it sees a given string. The zero value is
+// invalid; please fill all the fields marked as MANDATORY.
+type DPIDropTrafficForString struct {
+	// Logger is the MANDATORY logger
+	Logger Logger
+
+	// ServerIPAddress is the MANDATORY server endpoint IP address.
+	ServerIPAddress string
+
+	// ServerPort is the MANDATORY server endpoint port.
+	ServerPort uint16
+
+	// SNI is the MANDATORY string
+	String string
+}
+
+var _ DPIRule = &DPIDropTrafficForString{}
+
+// Filter implements DPIRule
+func (r *DPIDropTrafficForString) Filter(
+	direction DPIDirection, packet *DissectedPacket) (*DPIPolicy, bool) {
+	// short circuit for the return path
+	if direction != DPIDirectionClientToServer {
+		return nil, false
+	}
+
+	// short circuit for UDP packets
+	if packet.TransportProtocol() != layers.IPProtocolTCP {
+		return nil, false
+	}
+
+	// make sure the remote server is filtered
+	if !packet.MatchesDestination(layers.IPProtocolTCP, r.ServerIPAddress, r.ServerPort) {
+		return nil, false
+	}
+
+	// short circuit in case of misconfiguration
+	if r.String == "" {
+		return nil, false
+	}
+
+	// if the packet is not offending, accept it
+	if !bytes.Contains(packet.TCP.Payload, []byte(r.String)) {
+		return nil, false
+	}
+
+	r.Logger.Infof(
+		"netem: dpi: dropping traffic for flow %s:%d %s:%d/%s because it contains %s",
+		packet.SourceIPAddress(),
+		packet.SourcePort(),
+		packet.DestinationIPAddress(),
+		packet.DestinationPort(),
+		packet.TransportProtocol(),
+		r.String,
 	)
 	policy := &DPIPolicy{
 		Delay:   0,

--- a/example_dpi_test.go
+++ b/example_dpi_test.go
@@ -381,7 +381,7 @@ func Example_dpiSpoofBlockpageForString() {
 
 	// add DPI rule that drops traffic for the www.example.com string
 	dpi.AddRule(&netem.DPISpoofBlockpageForString{
-		Blockpage:       netem.DPIFormatHTTPResponse(blockpage),
+		HTTPResponse:    netem.DPIFormatHTTPResponse(blockpage),
 		Logger:          apexlog.Log,
 		ServerIPAddress: "5.4.3.21",
 		ServerPort:      80,

--- a/example_dpi_test.go
+++ b/example_dpi_test.go
@@ -1,0 +1,441 @@
+package netem_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"time"
+
+	apexlog "github.com/apex/log"
+	"github.com/ooni/netem"
+)
+
+// This example shows how to use DPI to provoke an EOF when you see an offending string.
+func Example_dpiCloseConnectionForString() {
+	// Create a star topology for our hosts.
+	topology, err := netem.NewStarTopology(&netem.NullLogger{})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer topology.Close()
+
+	// Create DPI engine in the client link
+	dpi := netem.NewDPIEngine(&netem.NullLogger{})
+
+	// Add client stack to topology. Note that we don't need to
+	// close the clientStack: the topology will do that.
+	//
+	// Note that we need to add delay because several DPI rules
+	// rely on race conditions and delay helps.
+	clientStack, err := topology.AddHost(
+		"10.0.0.1", // host IP address
+		"8.8.8.8",  // host DNS resolver IP address
+		&netem.LinkConfig{
+			LeftToRightDelay: time.Millisecond,
+			RightToLeftDelay: time.Millisecond,
+			DPIEngine:        dpi,
+		},
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Add DNS server stack to topology.
+	dnsServerStack, err := topology.AddHost(
+		"8.8.8.8",
+		"8.8.8.8", // this host is its own DNS resolver
+		&netem.LinkConfig{
+			LeftToRightDelay: time.Millisecond,
+			RightToLeftDelay: time.Millisecond,
+		},
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Add HTTPS server stack to topology.
+	httpsServerStack, err := topology.AddHost(
+		"5.4.3.21",
+		"8.8.8.8",
+		&netem.LinkConfig{
+			LeftToRightDelay: time.Millisecond,
+			RightToLeftDelay: time.Millisecond,
+		},
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// spawn a DNS server with the required configuration.
+	dnsConfig := netem.NewDNSConfig()
+	dnsConfig.AddRecord("www.example.com", "", "5.4.3.21")
+	dnsConfig.AddRecord("example.com", "", "5.4.3.21")
+	dnsServer, err := netem.NewDNSServer(
+		&netem.NullLogger{},
+		dnsServerStack,
+		"8.8.8.8",
+		dnsConfig,
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer dnsServer.Close()
+
+	// spawn an HTTP server with the required configuration
+	mux := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("Bonsoir, Elliot!"))
+	})
+	httpsAddr := &net.TCPAddr{
+		IP:   net.ParseIP("5.4.3.21"),
+		Port: 80,
+	}
+	httpsListener, err := httpsServerStack.ListenTCP("tcp", httpsAddr)
+	if err != nil {
+		log.Fatal(err)
+	}
+	httpsServer := &http.Server{
+		Handler: mux,
+	}
+	go httpsServer.Serve(httpsListener)
+	defer httpsServer.Close()
+
+	// create an HTTP transport using the clientStack
+	txp := netem.NewHTTPTransport(clientStack)
+
+	// add DPI rule that closes the connection for the www.example.com string
+	dpi.AddRule(&netem.DPICloseConnectionForString{
+		Logger:          &netem.NullLogger{},
+		ServerIPAddress: "5.4.3.21",
+		ServerPort:      80,
+		String:          "www.example.com",
+	})
+
+	// Note that all the code that follows is standard Go code that
+	// would work for any implementation of http.RoundTripper.
+
+	{
+		// create HTTP request
+		req, err := http.NewRequest("GET", "http://www.example.com/", nil)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// perform HTTP round trip
+		resp, err := txp.RoundTrip(req)
+		fmt.Printf("%s %v\n", err.Error(), resp == nil)
+	}
+
+	{
+		// create HTTP request
+		req, err := http.NewRequest("GET", "http://example.com/", nil)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// perform HTTP round trip
+		resp, err := txp.RoundTrip(req)
+		fmt.Printf("%v %v\n", err != nil, resp == nil)
+		defer resp.Body.Close()
+	}
+
+	// Output:
+	// EOF true
+	// false false
+	//
+}
+
+// This example shows how to use DPI to drop traffic after you see a given string,
+func Example_dpiDropTrafficForString() {
+	// Create a star topology for our hosts.
+	topology, err := netem.NewStarTopology(&netem.NullLogger{})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer topology.Close()
+
+	// Create DPI engine in the client link
+	dpi := netem.NewDPIEngine(&netem.NullLogger{})
+
+	// Add client stack to topology. Note that we don't need to
+	// close the clientStack: the topology will do that.
+	//
+	// Note that we need to add delay because several DPI rules
+	// rely on race conditions and delay helps.
+	clientStack, err := topology.AddHost(
+		"10.0.0.1", // host IP address
+		"8.8.8.8",  // host DNS resolver IP address
+		&netem.LinkConfig{
+			LeftToRightDelay: time.Millisecond,
+			RightToLeftDelay: time.Millisecond,
+			DPIEngine:        dpi,
+		},
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Add DNS server stack to topology.
+	dnsServerStack, err := topology.AddHost(
+		"8.8.8.8",
+		"8.8.8.8", // this host is its own DNS resolver
+		&netem.LinkConfig{
+			LeftToRightDelay: time.Millisecond,
+			RightToLeftDelay: time.Millisecond,
+		},
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Add HTTPS server stack to topology.
+	httpsServerStack, err := topology.AddHost(
+		"5.4.3.21",
+		"8.8.8.8",
+		&netem.LinkConfig{
+			LeftToRightDelay: time.Millisecond,
+			RightToLeftDelay: time.Millisecond,
+		},
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// spawn a DNS server with the required configuration.
+	dnsConfig := netem.NewDNSConfig()
+	dnsConfig.AddRecord("www.example.com", "", "5.4.3.21")
+	dnsConfig.AddRecord("example.com", "", "5.4.3.21")
+	dnsServer, err := netem.NewDNSServer(
+		&netem.NullLogger{},
+		dnsServerStack,
+		"8.8.8.8",
+		dnsConfig,
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer dnsServer.Close()
+
+	// spawn an HTTP server with the required configuration
+	mux := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("Bonsoir, Elliot!"))
+	})
+	httpsAddr := &net.TCPAddr{
+		IP:   net.ParseIP("5.4.3.21"),
+		Port: 80,
+	}
+	httpsListener, err := httpsServerStack.ListenTCP("tcp", httpsAddr)
+	if err != nil {
+		log.Fatal(err)
+	}
+	httpsServer := &http.Server{
+		Handler: mux,
+	}
+	go httpsServer.Serve(httpsListener)
+	defer httpsServer.Close()
+
+	// create an HTTP transport using the clientStack
+	txp := netem.NewHTTPTransport(clientStack)
+
+	// add DPI rule that drops traffic for the www.example.com string
+	dpi.AddRule(&netem.DPIDropTrafficForString{
+		Logger:          &netem.NullLogger{},
+		ServerIPAddress: "5.4.3.21",
+		ServerPort:      80,
+		String:          "www.example.com",
+	})
+
+	// Note that all the code that follows is standard Go code that
+	// would work for any implementation of http.RoundTripper.
+
+	{
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		// create HTTP request
+		req, err := http.NewRequestWithContext(ctx, "GET", "http://www.example.com/", nil)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// perform HTTP round trip
+		resp, err := txp.RoundTrip(req)
+		fmt.Printf("%s - %v\n", err.Error(), resp == nil)
+	}
+
+	{
+		// create HTTP request
+		req, err := http.NewRequest("GET", "http://example.com/", nil)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// perform HTTP round trip
+		resp, err := txp.RoundTrip(req)
+		fmt.Printf("%v - %v\n", err != nil, resp == nil)
+		defer resp.Body.Close()
+	}
+
+	// Output:
+	// context deadline exceeded - true
+	// false - false
+	//
+}
+
+// This example shows how to use DPI to spoof a blockpage for a string
+func Example_dpiSpoofBlockpageForString() {
+	// Create a star topology for our hosts.
+	topology, err := netem.NewStarTopology(&netem.NullLogger{})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer topology.Close()
+
+	// Create DPI engine in the client link
+	dpi := netem.NewDPIEngine(&netem.NullLogger{})
+
+	// Add client stack to topology. Note that we don't need to
+	// close the clientStack: the topology will do that.
+	//
+	// Note that we need to add delay because several DPI rules
+	// rely on race conditions and delay helps.
+	clientStack, err := topology.AddHost(
+		"10.0.0.1", // host IP address
+		"8.8.8.8",  // host DNS resolver IP address
+		&netem.LinkConfig{
+			DPIEngine:        dpi,
+			LeftNICWrapper:   netem.NewPCAPDumper("client.pcap", &netem.NullLogger{}),
+			LeftToRightDelay: time.Millisecond,
+			RightToLeftDelay: time.Millisecond,
+		},
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Add DNS server stack to topology.
+	dnsServerStack, err := topology.AddHost(
+		"8.8.8.8",
+		"8.8.8.8", // this host is its own DNS resolver
+		&netem.LinkConfig{
+			LeftToRightDelay: time.Millisecond,
+			RightToLeftDelay: time.Millisecond,
+		},
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Add HTTPS server stack to topology.
+	httpsServerStack, err := topology.AddHost(
+		"5.4.3.21",
+		"8.8.8.8",
+		&netem.LinkConfig{
+			LeftToRightDelay: time.Millisecond,
+			RightToLeftDelay: time.Millisecond,
+		},
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// spawn a DNS server with the required configuration.
+	dnsConfig := netem.NewDNSConfig()
+	dnsConfig.AddRecord("www.example.com", "", "5.4.3.21")
+	dnsConfig.AddRecord("example.com", "", "5.4.3.21")
+	dnsServer, err := netem.NewDNSServer(
+		&netem.NullLogger{},
+		dnsServerStack,
+		"8.8.8.8",
+		dnsConfig,
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer dnsServer.Close()
+
+	// spawn an HTTP server with the required configuration
+	mux := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("Bonsoir, Elliot!"))
+	})
+	httpsAddr := &net.TCPAddr{
+		IP:   net.ParseIP("5.4.3.21"),
+		Port: 80,
+	}
+	httpsListener, err := httpsServerStack.ListenTCP("tcp", httpsAddr)
+	if err != nil {
+		log.Fatal(err)
+	}
+	httpsServer := &http.Server{
+		Handler: mux,
+	}
+	go httpsServer.Serve(httpsListener)
+	defer httpsServer.Close()
+
+	// create an HTTP transport using the clientStack
+	txp := netem.NewHTTPTransport(clientStack)
+
+	blockpage := []byte(`<html><head><title>451 Unavailable For Legal Reasons</title></head><body><center><h1>451 Unavailable For Legal Reasons</h1></center><p>This content is not available in your jurisdiction.</p></body></html>`)
+
+	// add DPI rule that drops traffic for the www.example.com string
+	dpi.AddRule(&netem.DPISpoofBlockpageForString{
+		Blockpage:       netem.DPIFormatHTTPResponse(blockpage),
+		Logger:          apexlog.Log,
+		ServerIPAddress: "5.4.3.21",
+		ServerPort:      80,
+		String:          "www.example.com",
+	})
+
+	// Note that all the code that follows is standard Go code that
+	// would work for any implementation of http.RoundTripper.
+
+	{
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		// create HTTP request
+		req, err := http.NewRequestWithContext(ctx, "GET", "http://www.example.com/", nil)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// perform HTTP round trip
+		resp, err := txp.RoundTrip(req)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer resp.Body.Close()
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("%s\n", string(respBody))
+	}
+
+	{
+		// create HTTP request
+		req, err := http.NewRequest("GET", "http://example.com/", nil)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// perform HTTP round trip
+		resp, err := txp.RoundTrip(req)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer resp.Body.Close()
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("%s\n", string(respBody))
+	}
+
+	// Output:
+	// <html><head><title>451 Unavailable For Legal Reasons</title></head><body><center><h1>451 Unavailable For Legal Reasons</h1></center><p>This content is not available in your jurisdiction.</p></body></html>
+	// Bonsoir, Elliot!
+	//
+}


### PR DESCRIPTION
This diff implements the missing DPI rules required to complete https://github.com/ooni/probe/issues/1803:

* `DPICloseConnectionForString` sends a FIN|ACK when it sees a string (e.g., a host header)
* `DPISpoofBlockpageForString` spoofs a blockpage when it sees a string (e.g., a host header)
* `DPIDropTrafficForString` drops traffic when it sees a string (e.g., a host header)

While there, fix bug where the Ack number was not Seq +1 in all cases but in `DPICloseConnectionForServerEndpoint` and instead make sure it's always correctly set when reflecting. Also, improve reflection code.

Also, acknowledge that the test suite is overly complex and start relying on examples to provide minimal checks.

Also, double check that there is essential coverage for all DPI rules.