### PR TITLE
feat: fork google/martian/v3/mitm to build expired certs

### DIFF
--- a/mitmx/mitmx.go
+++ b/mitmx/mitmx.go
@@ -1,0 +1,329 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mitmx provides tooling for MITMing TLS connections. It provides
+// tooling to create CA certs and generate TLS configs that can be used to MITM
+// a TLS connection with a provided CA certificate.
+//
+// This package is a fork of the mitm package in github.com/google/martian/v3.
+package mitmx
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"math/big"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/google/martian/v3/h2"
+	"github.com/google/martian/v3/log"
+)
+
+// MaxSerialNumber is the upper boundary that is used to create unique serial
+// numbers for the certificate. This can be any unsigned integer up to 20
+// bytes (2^(8*20)-1).
+var MaxSerialNumber = big.NewInt(0).SetBytes(bytes.Repeat([]byte{255}, 20))
+
+// Config is a set of configuration values that are used to build TLS configs
+// capable of MITM.
+type Config struct {
+	ca                     *x509.Certificate
+	capriv                 interface{}
+	priv                   *rsa.PrivateKey
+	keyID                  []byte
+	validity               time.Duration
+	org                    string
+	h2Config               *h2.Config
+	roots                  *x509.CertPool
+	skipVerify             bool
+	handshakeErrorCallback func(*http.Request, error)
+
+	certmu sync.RWMutex
+	certs  map[string]*tls.Certificate
+}
+
+// NewAuthority creates a new CA certificate and associated
+// private key.
+func NewAuthority(name, organization string, validity time.Duration) (*x509.Certificate, *rsa.PrivateKey, error) {
+	return NewAuthorityWithTimeNow(name, organization, validity, time.Now)
+}
+
+// NewAuthorityWithTimeNow is like NewAuthority but allows to customize the time.Now func
+func NewAuthorityWithTimeNow(
+	name, organization string, validity time.Duration, timeNow func() time.Time) (*x509.Certificate, *rsa.PrivateKey, error) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+	pub := priv.Public()
+
+	// Subject Key Identifier support for end entity certificate.
+	// https://www.ietf.org/rfc/rfc3280.txt (section 4.2.1.2)
+	pkixpub, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return nil, nil, err
+	}
+	h := sha1.New()
+	h.Write(pkixpub)
+	keyID := h.Sum(nil)
+
+	// TODO: keep a map of used serial numbers to avoid potentially reusing a
+	// serial multiple times.
+	serial, err := rand.Int(rand.Reader, MaxSerialNumber)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName:   name,
+			Organization: []string{organization},
+		},
+		SubjectKeyId:          keyID,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		NotBefore:             timeNow().Add(-validity),
+		NotAfter:              timeNow().Add(validity),
+		DNSNames:              []string{name},
+		IsCA:                  true,
+	}
+
+	raw, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, pub, priv)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Parse certificate bytes so that we have a leaf certificate.
+	x509c, err := x509.ParseCertificate(raw)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return x509c, priv, nil
+}
+
+// NewConfig creates a MITM config using the CA certificate and
+// private key to generate on-the-fly certificates.
+func NewConfig(ca *x509.Certificate, privateKey interface{}) (*Config, error) {
+	roots := x509.NewCertPool()
+	roots.AddCert(ca)
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+	pub := priv.Public()
+
+	// Subject Key Identifier support for end entity certificate.
+	// https://www.ietf.org/rfc/rfc3280.txt (section 4.2.1.2)
+	pkixpub, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return nil, err
+	}
+	h := sha1.New()
+	h.Write(pkixpub)
+	keyID := h.Sum(nil)
+
+	return &Config{
+		ca:       ca,
+		capriv:   privateKey,
+		priv:     priv,
+		keyID:    keyID,
+		validity: time.Hour,
+		org:      "Martian Proxy",
+		certs:    make(map[string]*tls.Certificate),
+		roots:    roots,
+	}, nil
+}
+
+// SetValidity sets the validity window around the current time that the
+// certificate is valid for.
+func (c *Config) SetValidity(validity time.Duration) {
+	c.validity = validity
+}
+
+// SkipTLSVerify skips the TLS certification verification check.
+func (c *Config) SkipTLSVerify(skip bool) {
+	c.skipVerify = skip
+}
+
+// SetOrganization sets the organization of the certificate.
+func (c *Config) SetOrganization(org string) {
+	c.org = org
+}
+
+// SetH2Config configures processing of HTTP/2 streams.
+func (c *Config) SetH2Config(h2Config *h2.Config) {
+	c.h2Config = h2Config
+}
+
+// H2Config returns the current HTTP/2 configuration.
+func (c *Config) H2Config() *h2.Config {
+	return c.h2Config
+}
+
+// SetHandshakeErrorCallback sets the handshakeErrorCallback function.
+func (c *Config) SetHandshakeErrorCallback(cb func(*http.Request, error)) {
+	c.handshakeErrorCallback = cb
+}
+
+// HandshakeErrorCallback calls the handshakeErrorCallback function in this
+// Config, if it is non-nil. Request is the connect request that this handshake
+// is being executed through.
+func (c *Config) HandshakeErrorCallback(r *http.Request, err error) {
+	if c.handshakeErrorCallback != nil {
+		c.handshakeErrorCallback(r, err)
+	}
+}
+
+// TLS returns a *tls.Config that will generate certificates on-the-fly using
+// the SNI extension in the TLS ClientHello.
+func (c *Config) TLS() *tls.Config {
+	return &tls.Config{
+		InsecureSkipVerify: c.skipVerify,
+		GetCertificate: func(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			if clientHello.ServerName == "" {
+				return nil, errors.New("mitm: SNI not provided, failed to build certificate")
+			}
+
+			return c.cert(clientHello.ServerName)
+		},
+		NextProtos: []string{"http/1.1"},
+	}
+}
+
+// TLSForHost returns a *tls.Config that will generate certificates on-the-fly
+// using SNI from the connection, or fall back to the provided hostname.
+func (c *Config) TLSForHost(hostname string) *tls.Config {
+	nextProtos := []string{"http/1.1"}
+	if c.h2AllowedHost(hostname) {
+		nextProtos = []string{"h2", "http/1.1"}
+	}
+	return &tls.Config{
+		InsecureSkipVerify: c.skipVerify,
+		GetCertificate: func(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			host := clientHello.ServerName
+			if host == "" {
+				host = hostname
+			}
+
+			return c.cert(host)
+		},
+		NextProtos: nextProtos,
+	}
+}
+
+func (c *Config) h2AllowedHost(host string) bool {
+	return c.h2Config != nil &&
+		c.h2Config.AllowedHostsFilter != nil &&
+		c.h2Config.AllowedHostsFilter(host)
+}
+
+func (c *Config) cert(hostname string) (*tls.Certificate, error) {
+	// Remove the port if it exists.
+	host, _, err := net.SplitHostPort(hostname)
+	if err == nil {
+		hostname = host
+	}
+
+	c.certmu.RLock()
+	tlsc, ok := c.certs[hostname]
+	c.certmu.RUnlock()
+
+	if ok {
+		log.Debugf("mitm: cache hit for %s", hostname)
+
+		// Check validity of the certificate for hostname match, expiry, etc. In
+		// particular, if the cached certificate has expired, create a new one.
+		if _, err := tlsc.Leaf.Verify(x509.VerifyOptions{
+			DNSName: hostname,
+			Roots:   c.roots,
+		}); err == nil {
+			return tlsc, nil
+		}
+
+		log.Debugf("mitm: invalid certificate in cache for %s", hostname)
+	}
+
+	log.Debugf("mitm: cache miss for %s", hostname)
+
+	tlsc, err = c.NewCertWithoutCacheWithTimeNow(hostname, time.Now)
+	if err != nil {
+		return nil, err
+	}
+
+	c.certmu.Lock()
+	c.certs[hostname] = tlsc
+	c.certmu.Unlock()
+
+	return tlsc, nil
+}
+
+// NewCertWithoutCacheWithTimeNow is the most fundamental building block for building a certificate
+// that completely bypasses caching and allows for setting a custom time.Now func.
+func (c *Config) NewCertWithoutCacheWithTimeNow(hostname string, timeNow func() time.Time) (*tls.Certificate, error) {
+	serial, err := rand.Int(rand.Reader, MaxSerialNumber)
+	if err != nil {
+		return nil, err
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName:   hostname,
+			Organization: []string{c.org},
+		},
+		SubjectKeyId:          c.keyID,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		NotBefore:             timeNow().Add(-c.validity),
+		NotAfter:              timeNow().Add(c.validity),
+	}
+
+	if ip := net.ParseIP(hostname); ip != nil {
+		tmpl.IPAddresses = []net.IP{ip}
+	} else {
+		tmpl.DNSNames = []string{hostname}
+	}
+
+	raw, err := x509.CreateCertificate(rand.Reader, tmpl, c.ca, c.priv.Public(), c.capriv)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse certificate bytes so that we have a leaf certificate.
+	x509c, err := x509.ParseCertificate(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	tlsc := &tls.Certificate{
+		Certificate: [][]byte{raw, c.ca.Raw},
+		PrivateKey:  c.priv,
+		Leaf:        x509c,
+	}
+
+	return tlsc, nil
+}

--- a/mitmx/mitmx_test.go
+++ b/mitmx/mitmx_test.go
@@ -1,0 +1,205 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mitmx
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestMITM(t *testing.T) {
+	ca, priv, err := NewAuthority("martian.proxy", "Martian Authority", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("NewAuthority(): got %v, want no error", err)
+	}
+
+	c, err := NewConfig(ca, priv)
+	if err != nil {
+		t.Fatalf("NewConfig(): got %v, want no error", err)
+	}
+
+	c.SetValidity(20 * time.Hour)
+	c.SetOrganization("Test Organization")
+
+	protos := []string{"http/1.1"}
+
+	conf := c.TLS()
+	if got := conf.NextProtos; !reflect.DeepEqual(got, protos) {
+		t.Errorf("conf.NextProtos: got %v, want %v", got, protos)
+	}
+	if conf.InsecureSkipVerify {
+		t.Error("conf.InsecureSkipVerify: got true, want false")
+	}
+
+	// Simulate a TLS connection without SNI.
+	clientHello := &tls.ClientHelloInfo{
+		ServerName: "",
+	}
+
+	if _, err := conf.GetCertificate(clientHello); err == nil {
+		t.Fatal("conf.GetCertificate(): got nil, want error")
+	}
+
+	// Simulate a TLS connection with SNI.
+	clientHello.ServerName = "example.com"
+
+	tlsc, err := conf.GetCertificate(clientHello)
+	if err != nil {
+		t.Fatalf("conf.GetCertificate(): got %v, want no error", err)
+	}
+
+	x509c := tlsc.Leaf
+	if got, want := x509c.Subject.CommonName, "example.com"; got != want {
+		t.Errorf("x509c.Subject.CommonName: got %q, want %q", got, want)
+	}
+
+	c.SkipTLSVerify(true)
+
+	conf = c.TLSForHost("example.com")
+	if got := conf.NextProtos; !reflect.DeepEqual(got, protos) {
+		t.Errorf("conf.NextProtos: got %v, want %v", got, protos)
+	}
+	if !conf.InsecureSkipVerify {
+		t.Error("conf.InsecureSkipVerify: got false, want true")
+	}
+
+	// Set SNI, takes precedence over host.
+	clientHello.ServerName = "google.com"
+	tlsc, err = conf.GetCertificate(clientHello)
+	if err != nil {
+		t.Fatalf("conf.GetCertificate(): got %v, want no error", err)
+	}
+
+	x509c = tlsc.Leaf
+	if got, want := x509c.Subject.CommonName, "google.com"; got != want {
+		t.Errorf("x509c.Subject.CommonName: got %q, want %q", got, want)
+	}
+
+	// Reset SNI to fallback to hostname.
+	clientHello.ServerName = ""
+	tlsc, err = conf.GetCertificate(clientHello)
+	if err != nil {
+		t.Fatalf("conf.GetCertificate(): got %v, want no error", err)
+	}
+
+	x509c = tlsc.Leaf
+	if got, want := x509c.Subject.CommonName, "example.com"; got != want {
+		t.Errorf("x509c.Subject.CommonName: got %q, want %q", got, want)
+	}
+}
+
+func TestCert(t *testing.T) {
+	ca, priv, err := NewAuthority("martian.proxy", "Martian Authority", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("NewAuthority(): got %v, want no error", err)
+	}
+
+	c, err := NewConfig(ca, priv)
+	if err != nil {
+		t.Fatalf("NewConfig(): got %v, want no error", err)
+	}
+
+	tlsc, err := c.cert("example.com")
+	if err != nil {
+		t.Fatalf("c.cert(%q): got %v, want no error", "example.com:8080", err)
+	}
+
+	if tlsc.Certificate == nil {
+		t.Error("tlsc.Certificate: got nil, want certificate bytes")
+	}
+	if tlsc.PrivateKey == nil {
+		t.Error("tlsc.PrivateKey: got nil, want private key")
+	}
+
+	x509c := tlsc.Leaf
+	if x509c == nil {
+		t.Fatal("x509c: got nil, want *x509.Certificate")
+	}
+
+	if got := x509c.SerialNumber; got.Cmp(MaxSerialNumber) >= 0 {
+		t.Errorf("x509c.SerialNumber: got %v, want <= MaxSerialNumber", got)
+	}
+	if got, want := x509c.Subject.CommonName, "example.com"; got != want {
+		t.Errorf("X509c.Subject.CommonName: got %q, want %q", got, want)
+	}
+	if err := x509c.VerifyHostname("example.com"); err != nil {
+		t.Errorf("x509c.VerifyHostname(%q): got %v, want no error", "example.com", err)
+	}
+
+	if got, want := x509c.Subject.Organization, []string{"Martian Proxy"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("x509c.Subject.Organization: got %v, want %v", got, want)
+	}
+
+	if got := x509c.SubjectKeyId; got == nil {
+		t.Error("x509c.SubjectKeyId: got nothing, want key ID")
+	}
+	if !x509c.BasicConstraintsValid {
+		t.Error("x509c.BasicConstraintsValid: got false, want true")
+	}
+
+	if got, want := x509c.KeyUsage, x509.KeyUsageKeyEncipherment; got&want == 0 {
+		t.Error("x509c.KeyUsage: got nothing, want to include x509.KeyUsageKeyEncipherment")
+	}
+	if got, want := x509c.KeyUsage, x509.KeyUsageDigitalSignature; got&want == 0 {
+		t.Error("x509c.KeyUsage: got nothing, want to include x509.KeyUsageDigitalSignature")
+	}
+
+	want := []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+	if got := x509c.ExtKeyUsage; !reflect.DeepEqual(got, want) {
+		t.Errorf("x509c.ExtKeyUsage: got %v, want %v", got, want)
+	}
+
+	if got, want := x509c.DNSNames, []string{"example.com"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("x509c.DNSNames: got %v, want %v", got, want)
+	}
+
+	before := time.Now().Add(-2 * time.Hour)
+	if got := x509c.NotBefore; before.After(got) {
+		t.Errorf("x509c.NotBefore: got %v, want after %v", got, before)
+	}
+
+	after := time.Now().Add(2 * time.Hour)
+	if got := x509c.NotAfter; !after.After(got) {
+		t.Errorf("x509c.NotAfter: got %v, want before %v", got, want)
+	}
+
+	// Retrieve cached certificate.
+	tlsc2, err := c.cert("example.com")
+	if err != nil {
+		t.Fatalf("c.cert(%q): got %v, want no error", "example.com", err)
+	}
+	if tlsc != tlsc2 {
+		t.Error("tlsc2: got new certificate, want cached certificate")
+	}
+
+	// TLS certificate for IP.
+	tlsc, err = c.cert("10.0.0.1:8227")
+	if err != nil {
+		t.Fatalf("c.cert(%q): got %v, want no error", "10.0.0.1:8227", err)
+	}
+	x509c = tlsc.Leaf
+
+	if got, want := len(x509c.IPAddresses), 1; got != want {
+		t.Fatalf("len(x509c.IPAddresses): got %d, want %d", got, want)
+	}
+
+	if got, want := x509c.IPAddresses[0], net.ParseIP("10.0.0.1"); !got.Equal(want) {
+		t.Fatalf("x509c.IPAddresses: got %v, want %v", got, want)
+	}
+}

--- a/tlsmitm.go
+++ b/tlsmitm.go
@@ -10,22 +10,24 @@ import (
 	"crypto/x509"
 	"time"
 
-	"github.com/google/martian/v3/mitm"
+	mitm "github.com/ooni/netem/mitmx"
 )
 
 // TLSMITMConfig contains configuration for TLS MITM operations. You MUST use the
 // [NewMITMConfig] factory to create a new instance. You will need to pass this
 // instance to [NewGVisorStack] so that all the [GvisorStack] can communicate with
 // each other using the same underlying (fake) root CA pool.
+//
+// The zero value of this struct is invalid; please, use [NewTLSMITMConfig].
 type TLSMITMConfig struct {
-	// cert is the fake CA certificate for MITM.
-	cert *x509.Certificate
+	// Cert is the fake CA certificate for MITM.
+	Cert *x509.Certificate
 
-	// config is the MITM config to generate certificates on the fly.
-	config *mitm.Config
+	// Config is the MITM Config to generate certificates on the fly.
+	Config *mitm.Config
 
-	// key is the private key that signed the mitmCert.
-	key *rsa.PrivateKey
+	// Key is the private Key that signed the mitmCert.
+	Key *rsa.PrivateKey
 }
 
 // NewTLSMITMConfig creates a new [MITMConfig].
@@ -39,9 +41,9 @@ func NewTLSMITMConfig() (*TLSMITMConfig, error) {
 		return nil, err
 	}
 	mitmConfig := &TLSMITMConfig{
-		cert:   cert,
-		config: config,
-		key:    key,
+		Cert:   cert,
+		Config: config,
+		Key:    key,
 	}
 	return mitmConfig, nil
 }
@@ -49,7 +51,7 @@ func NewTLSMITMConfig() (*TLSMITMConfig, error) {
 // CertPool returns an [x509.CertPool] using the given [MITMConfig].
 func (c *TLSMITMConfig) CertPool() (*x509.CertPool, error) {
 	pool := x509.NewCertPool()
-	pool.AddCert(c.cert)
+	pool.AddCert(c.Cert)
 	return pool, nil
 }
 
@@ -59,7 +61,7 @@ func (c *TLSMITMConfig) TLSConfig() *tls.Config {
 	return &tls.Config{
 		InsecureSkipVerify: false,
 		GetCertificate: func(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
-			martianConfig := c.config.TLSForHost(tlsAddrFromClientHello(clientHello))
+			martianConfig := c.Config.TLSForHost(tlsAddrFromClientHello(clientHello))
 			return martianConfig.GetCertificate(clientHello)
 		},
 		NextProtos: []string{"http/1.1"},

--- a/tlsmitm_test.go
+++ b/tlsmitm_test.go
@@ -1,0 +1,59 @@
+package netem
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/apex/log"
+)
+
+func TestMITMWeCanGenerateAnExpiredCertificate(t *testing.T) {
+	topology := Must1(NewStarTopology(log.Log))
+	defer topology.Close()
+
+	serverStack := Must1(topology.AddHost("10.0.0.1", "0.0.0.0", &LinkConfig{}))
+	clientStack := Must1(topology.AddHost("10.0.0.2", "0.0.0.0", &LinkConfig{}))
+
+	serverAddr := &net.TCPAddr{IP: net.IPv4(10, 0, 0, 1), Port: 443}
+	serverListener := Must1(serverStack.ListenTCP("tcp", serverAddr))
+
+	serverServer := &http.Server{
+		Handler: http.NewServeMux(),
+		TLSConfig: &tls.Config{
+			GetCertificate: func(chi *tls.ClientHelloInfo) (*tls.Certificate, error) {
+				// obtain the underlying MITM mechanism and force a long time in the past as
+				// the certificate generation time for testing
+				config := topology.TLSMITMConfig()
+				return config.Config.NewCertWithoutCacheWithTimeNow(
+					chi.ServerName,
+					func() time.Time {
+						return time.Date(2017, time.July, 17, 0, 0, 0, 0, time.UTC)
+					},
+				)
+			},
+		},
+	}
+	go serverServer.ServeTLS(serverListener, "", "")
+	defer serverServer.Close()
+
+	tcpConn, err := clientStack.DialContext(context.Background(), "tcp", "10.0.0.1:443")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tcpConn.Close()
+
+	tlsClientConfig := &tls.Config{
+		RootCAs:    Must1(topology.TLSMITMConfig().CertPool()),
+		ServerName: "www.example.com",
+	}
+	tlsConn := tls.Client(tcpConn, tlsClientConfig)
+	err = tlsConn.HandshakeContext(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "x509: certificate has expired or is not yet valid") {
+		t.Fatal("unexpected error", err)
+	}
+}

--- a/topology.go
+++ b/topology.go
@@ -200,3 +200,8 @@ func (t *StarTopology) Close() error {
 	})
 	return nil
 }
+
+// TLSMITMConfig exposes the [TLSMITMConfig].
+func (t *StarTopology) TLSMITMConfig() *TLSMITMConfig {
+	return t.mitm
+}


### PR DESCRIPTION
To move forward with https://github.com/ooni/probe/issues/1803, I want to generate expired certificates. To this end, I have forked the mitm package to peek into internals and further customize certificate generation.

I forked at https://github.com/google/martian/commit/19163e1b8984e2577ea366d8aa97f0f75c6f6ac6.

The diff between the original code and my code is the following:

```diff
--- mitmx/mitm.go.orig	2023-09-06 10:42:30
+++ mitmx/mitmx.go	2023-09-06 10:46:28
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.

-// Package mitm provides tooling for MITMing TLS connections. It provides
+// Package mitmx provides tooling for MITMing TLS connections. It provides
 // tooling to create CA certs and generate TLS configs that can be used to MITM
 // a TLS connection with a provided CA certificate.
-package mitm
+//
+// This package is a fork of the mitm package in github.com/google/martian/v3.
+package mitmx

 import (
 	"bytes"
@@ -51,7 +53,6 @@
 	validity               time.Duration
 	org                    string
 	h2Config               *h2.Config
-	getCertificate         func(*tls.ClientHelloInfo) (*tls.Certificate, error)
 	roots                  *x509.CertPool
 	skipVerify             bool
 	handshakeErrorCallback func(*http.Request, error)
@@ -63,6 +64,12 @@
 // NewAuthority creates a new CA certificate and associated
 // private key.
 func NewAuthority(name, organization string, validity time.Duration) (*x509.Certificate, *rsa.PrivateKey, error) {
+	return NewAuthorityWithTimeNow(name, organization, validity, time.Now)
+}
+
+// NewAuthorityWithTimeNow is like NewAuthority but allows to customize the time.Now func
+func NewAuthorityWithTimeNow(
+	name, organization string, validity time.Duration, timeNow func() time.Time) (*x509.Certificate, *rsa.PrivateKey, error) {
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return nil, nil, err
@@ -96,8 +103,8 @@
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
-		NotBefore:             time.Now().Add(-validity),
-		NotAfter:              time.Now().Add(validity),
+		NotBefore:             timeNow().Add(-validity),
+		NotAfter:              timeNow().Add(validity),
 		DNSNames:              []string{name},
 		IsCA:                  true,
 	}
@@ -260,7 +267,22 @@
 	}

 	log.Debugf("mitm: cache miss for %s", hostname)
+
+	tlsc, err = c.NewCertWithoutCacheWithTimeNow(hostname, time.Now)
+	if err != nil {
+		return nil, err
+	}

+	c.certmu.Lock()
+	c.certs[hostname] = tlsc
+	c.certmu.Unlock()
+
+	return tlsc, nil
+}
+
+// NewCertWithoutCacheWithTimeNow is the most fundamental building block for building a certificate
+// that completely bypasses caching and allows for setting a custom time.Now func.
+func (c *Config) NewCertWithoutCacheWithTimeNow(hostname string, timeNow func() time.Time) (*tls.Certificate, error) {
 	serial, err := rand.Int(rand.Reader, MaxSerialNumber)
 	if err != nil {
 		return nil, err
@@ -276,8 +298,8 @@
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
-		NotBefore:             time.Now().Add(-c.validity),
-		NotAfter:              time.Now().Add(c.validity),
+		NotBefore:             timeNow().Add(-c.validity),
+		NotAfter:              timeNow().Add(c.validity),
 	}

 	if ip := net.ParseIP(hostname); ip != nil {
@@ -297,15 +319,11 @@
 		return nil, err
 	}

-	tlsc = &tls.Certificate{
+	tlsc := &tls.Certificate{
 		Certificate: [][]byte{raw, c.ca.Raw},
 		PrivateKey:  c.priv,
 		Leaf:        x509c,
 	}

-	c.certmu.Lock()
-	c.certs[hostname] = tlsc
-	c.certmu.Unlock()
-
 	return tlsc, nil
 }
```