### PR TITLE
fix(UNetStack): better compatibility with ooni/probe-cli models

### DIFF
--- a/model.go
+++ b/model.go
@@ -157,6 +157,9 @@ type UnderlyingNetwork interface {
 	// CA returns the CA we're using.
 	CA() *CA
 
+	// CACert returns the CA cert we're using.
+	CACert() *x509.Certificate
+
 	// DefaultCertPool returns the underlying cert pool to be used.
 	DefaultCertPool() *x509.CertPool
 

--- a/unetstack.go
+++ b/unetstack.go
@@ -6,6 +6,7 @@ package netem
 
 import (
 	"context"
+	"crypto/tls"
 	"crypto/x509"
 	"net"
 	"net/netip"
@@ -106,6 +107,17 @@ func NewUNetStack(
 // CA implements UnderlyingNetwork.
 func (gs *UNetStack) CA() *CA {
 	return gs.ca
+}
+
+// CACert implements UnderlyingNetwork.
+func (gs *UNetStack) CACert() *x509.Certificate {
+	return gs.ca.CACert
+}
+
+// MustServerTLSConfig is used by [github.com/ooni/probe-cli] code
+// when generating configuration for servers using TLS.
+func (gs *UNetStack) MustServerTLSConfig(commonName string, extraNames ...string) *tls.Config {
+	return gs.ca.MustServerTLSConfig(commonName, extraNames...)
 }
 
 // Logger implements HTTPUnderlyingNetwork.


### PR DESCRIPTION
The refactoring at https://github.com/ooni/netem/commit/45a7aa975636a8de271e07904ccd076a953618b0 was a bit too aggressive and we have lost some degree of interface level compatibility with ooni/probe-cli. Let's repair this:

* Add the `CACert` accessor required by ooni/probe-cli code.

* While there, also declare the accessor as being part of `UnderlyingNetwork`.

* We have a slight issue with `ServerTLSConfig`, which is expected by ooni/probe-cli and now is called `MustNewTLSConfig` and, additionally, requires the names for which to generate the certificate. We will solve these issues inside the ooni/probe-cli repository, but let's make sure the `UNetStack` has the correct method.

Part of https://github.com/ooni/probe/issues/2531