### PR TITLE
BREAKING CHANGE: unify UNetStack and CA's CertificationAuthority behavior

### DIFF
--- a/ca_test.go
+++ b/ca_test.go
@@ -112,7 +112,7 @@ func TestCAWeCanGenerateAnExpiredCertificate(t *testing.T) {
 		Handler: http.NewServeMux(),
 		TLSConfig: &tls.Config{
 			Certificates: []tls.Certificate{
-				*serverStack.CA().MustNewCertWithTimeNow(func() time.Time {
+				*serverStack.ca.MustNewCertWithTimeNow(func() time.Time {
 					return time.Date(2017, time.July, 17, 0, 0, 0, 0, time.UTC)
 				},
 					"www.example.com",

--- a/example_star_test.go
+++ b/example_star_test.go
@@ -77,7 +77,7 @@ func Example_starTopologyHTTPSAndDNS() {
 	}
 	httpsServer := &http.Server{
 		Handler:   mux,
-		TLSConfig: httpsServerStack.CA().MustServerTLSConfig("tyrell.wellick.name"),
+		TLSConfig: httpsServerStack.MustNewServerTLSConfig("tyrell.wellick.name"),
 	}
 	go httpsServer.ServeTLS(httpsListener, "", "") // empty string: use .TLSConfig
 	defer httpsServer.Close()

--- a/integration_test.go
+++ b/integration_test.go
@@ -308,7 +308,7 @@ func TestRoutingWorksHTTPS(t *testing.T) {
 		t.Fatal(err)
 	}
 	httpServer := &http.Server{
-		TLSConfig: serverStack.CA().MustServerTLSConfig("example.local", "10.0.0.1"),
+		TLSConfig: serverStack.MustNewServerTLSConfig("example.local", "10.0.0.1"),
 		Handler:   mux,
 	}
 	go httpServer.ServeTLS(listener, "", "") // empty strings mean: use TLSConfig

--- a/ndt0.go
+++ b/ndt0.go
@@ -249,7 +249,7 @@ func RunNDT0Server(
 	}
 
 	// generate a config for the given SNI and for the given IP addr
-	tlsConfig := stack.CA().MustServerTLSConfig(serverIPAddr.String(), serverNames...)
+	tlsConfig := stack.MustNewServerTLSConfig(serverIPAddr.String(), serverNames...)
 
 	// conditionally use TLS
 	ns := &Net{stack}

--- a/unetstack.go
+++ b/unetstack.go
@@ -45,9 +45,10 @@ type UNetStack struct {
 }
 
 var (
-	_ HTTPUnderlyingNetwork = &UNetStack{}
-	_ NIC                   = &UNetStack{}
-	_ UnderlyingNetwork     = &UNetStack{}
+	_ CertificationAuthority = &UNetStack{}
+	_ HTTPUnderlyingNetwork  = &UNetStack{}
+	_ NIC                    = &UNetStack{}
+	_ UnderlyingNetwork      = &UNetStack{}
 )
 
 // NewUNetStack constructs a new [UNetStack] instance.
@@ -104,20 +105,19 @@ func NewUNetStack(
 	return stack, nil
 }
 
-// CA implements UnderlyingNetwork.
-func (gs *UNetStack) CA() *CA {
-	return gs.ca
-}
-
-// CACert implements UnderlyingNetwork.
+// CACert implements CertificationAuthority.
 func (gs *UNetStack) CACert() *x509.Certificate {
-	return gs.ca.CACert
+	return gs.ca.CACert()
 }
 
-// MustServerTLSConfig is used by [github.com/ooni/probe-cli] code
-// when generating configuration for servers using TLS.
-func (gs *UNetStack) MustServerTLSConfig(commonName string, extraNames ...string) *tls.Config {
-	return gs.ca.MustServerTLSConfig(commonName, extraNames...)
+// DefaultCertPool implements CertificationAuthority.
+func (gs *UNetStack) DefaultCertPool() *x509.CertPool {
+	return gs.ca.DefaultCertPool()
+}
+
+// MustNewServerTLSConfig implements CertificationAuthority.
+func (gs *UNetStack) MustNewServerTLSConfig(commonName string, extraNames ...string) *tls.Config {
+	return gs.ca.MustNewServerTLSConfig(commonName, extraNames...)
 }
 
 // Logger implements HTTPUnderlyingNetwork.
@@ -158,11 +158,6 @@ func (gs *UNetStack) WriteFrame(frame *Frame) error {
 // Close shuts down the virtual network stack.
 func (gs *UNetStack) Close() error {
 	return gs.ns.Close()
-}
-
-// DefaultCertPool implements UnderlyingNetwork.
-func (gs *UNetStack) DefaultCertPool() *x509.CertPool {
-	return gs.ca.CertPool()
 }
 
 // DialContext implements UnderlyingNetwork.


### PR DESCRIPTION
The UNetStack and CA structures have similar functionality exposed through a different interface, which causes us to create an interface and a wrapper for the code in probe-cli.

I noticed about this when I was trying to integrate new netem changes, and it occurred to me we can just make the interfaces uniform here and avoid doing some additional work in probe-cli.

Note: this is a breaking change because `(*Ca).CACert` was a field and now is a method.

Also part of https://github.com/ooni/probe/issues/2531