### PR TITLE
BREAKING CHANGE: CertificationAuthority: add code to build certs

### DIFF
--- a/ca.go
+++ b/ca.go
@@ -155,7 +155,7 @@ func (ca *CA) MustNewTLSCertificate(commonName string, extraNames ...string) *tl
 	return ca.MustNewTLSCertificateWithTimeNow(time.Now, commonName, extraNames...)
 }
 
-// MustNewCertWithTimeNow is like [MustNewCert] but uses a custom [time.Now] func.
+// MustNewCertWithTimeNow implements [CertificationAuthority].
 //
 // This code is derived from github.com/google/martian/v3.
 //

--- a/ca_test.go
+++ b/ca_test.go
@@ -29,10 +29,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestCAMustNewCert(t *testing.T) {
+func TestCAMustNewTLSCertificate(t *testing.T) {
 	ca := MustNewCA()
 
-	tlsc := ca.MustNewCert("example.com", "www.example.com", "10.0.0.1", "10.0.0.2")
+	tlsc := ca.MustNewTLSCertificate("example.com", "www.example.com", "10.0.0.1", "10.0.0.2")
 
 	if tlsc.Certificate == nil {
 		t.Error("tlsc.Certificate: got nil, want certificate bytes")
@@ -112,7 +112,7 @@ func TestCAWeCanGenerateAnExpiredCertificate(t *testing.T) {
 		Handler: http.NewServeMux(),
 		TLSConfig: &tls.Config{
 			Certificates: []tls.Certificate{
-				*serverStack.ca.MustNewCertWithTimeNow(func() time.Time {
+				*serverStack.MustNewTLSCertificateWithTimeNow(func() time.Time {
 					return time.Date(2017, time.July, 17, 0, 0, 0, 0, time.UTC)
 				},
 					"www.example.com",

--- a/model.go
+++ b/model.go
@@ -37,6 +37,16 @@ type CertificationAuthority interface {
 	// the given common name and extra names, all of which could be
 	// either IPv4/IPv6 addresses or domain names.
 	MustNewServerTLSConfig(commonName string, extraNames ...string) *tls.Config
+
+	// MustNewTLSCertificate constructs a TLS certificate for
+	// the given common name and extra names, all of which could be
+	// either IPv4/IPv6 addresses or domain names.
+	MustNewTLSCertificate(commonName string, extraNames ...string) *tls.Certificate
+
+	// MustNewTLSCertificateWithTimeNow is like MustNewTLSCertificate
+	// but takes as input an explicit [time.Now] like func.
+	MustNewTLSCertificateWithTimeNow(timeNow func() time.Time,
+		commonName string, extraNames ...string) *tls.Certificate
 }
 
 // Frame contains an IPv4 or IPv6 packet.

--- a/unetstack.go
+++ b/unetstack.go
@@ -120,6 +120,17 @@ func (gs *UNetStack) MustNewServerTLSConfig(commonName string, extraNames ...str
 	return gs.ca.MustNewServerTLSConfig(commonName, extraNames...)
 }
 
+// MustNewTLSCertificate implements implements CertificationAuthority.
+func (gs *UNetStack) MustNewTLSCertificate(commonName string, extraNames ...string) *tls.Certificate {
+	return gs.ca.MustNewTLSCertificate(commonName, extraNames...)
+}
+
+// MustNewTLSCertificateWithTimeNow implements CertificationAuthority.
+func (gs *UNetStack) MustNewTLSCertificateWithTimeNow(timeNow func() time.Time,
+	commonName string, extraNames ...string) *tls.Certificate {
+	return gs.ca.MustNewTLSCertificateWithTimeNow(timeNow, commonName, extraNames...)
+}
+
 // Logger implements HTTPUnderlyingNetwork.
 func (gs *UNetStack) Logger() Logger {
 	return gs.ns.logger


### PR DESCRIPTION
It turns out we can further simplify the ooni/probe-cli implementation by adding more methods of `*CA` to `CertificationAuthority`.

Part of https://github.com/ooni/probe/issues/2531