### PR TITLE
fix(ca.go): use http/1.1 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ go get -u -v -d gvisor.dev/gvisor@COMMIT_HASH
 because [Gvisor](https://gvisor.dev/)'s default branch is not
 ready to be used with Go tools and `go get` would misbehave.
 
-When updating [Gvisor](https://gvisor.dev/) in this library, make sure 
+When updating [Gvisor](https://gvisor.dev/) in this library, make sure
 you pin to a commit from the [go](https://github.com/google/gvisor/tree/go) branch,
 which is the [Gvisor](https://gvisor.dev/) branch supporting go tools.
 
@@ -51,6 +51,10 @@ go test -race .
 and many tests will fail; it still seems to be fine under Linux.
 
 ## Usage
+
+TODO(bassosimone): this section needs to be updated because we have
+recently removed the `stdlib.go` file and functionality, since we have
+much better functionality inside of ooni/probe-cli.
 
 Existing Go code needs to be adjusted to support netem.
 

--- a/ca.go
+++ b/ca.go
@@ -145,8 +145,11 @@ func (ca *CA) DefaultCertPool() *x509.CertPool {
 
 // MustNewServerTLSConfig implements [CertificationAuthority].
 func (ca *CA) MustNewServerTLSConfig(commonName string, extraNames ...string) *tls.Config {
+	// Implementation note: we want to force http/1.1 because we have several tests
+	// where the connection is hijackable and we cannot hijack http2 connections.
 	return &tls.Config{
 		Certificates: []tls.Certificate{*ca.MustNewTLSCertificate(commonName, extraNames...)},
+		NextProtos:   []string{"http/1.1"},
 	}
 }
 


### PR DESCRIPTION
The previous martian code used http/1.1 by default. Now I know why: if using http2 we cannot hijack http connections anymore.

While there, mention `README.md` bug and how to address it.

Part of https://github.com/ooni/probe/issues/2531