### PR TITLE
feat: implement TCP-endpoint-based throttling

### DIFF
--- a/dpithrottle.go
+++ b/dpithrottle.go
@@ -20,7 +20,7 @@ type DPIThrottleTrafficForTLSSNI struct {
 	// Logger is the MANDATORY logger to use.
 	Logger Logger
 
-	// PLR is the OPTIONAL extra packet loss rate to apply to the packet
+	// PLR is the OPTIONAL extra packet loss rate to apply to the packet.
 	PLR float64
 
 	// SNI is the OPTIONAL offending SNI
@@ -61,6 +61,58 @@ func (r *DPIThrottleTrafficForTLSSNI) Filter(
 		packet.DestinationPort(),
 		packet.TransportProtocol(),
 		sni,
+	)
+	policy := &DPIPolicy{
+		Delay:   r.Delay,
+		Flags:   0,
+		PLR:     r.PLR,
+		Spoofed: nil,
+	}
+	return policy, true
+}
+
+// DPIThrottleTrafficForTCPEndpoint is a [DPIRule] that throttles traffic
+// for a given TCP endpoint. The zero value is not valid. Make sure
+// you initialize all fields marked as MANDATORY.
+type DPIThrottleTrafficForTCPEndpoint struct {
+	// Delay is the OPTIONAL extra delay to add to the flow.
+	Delay time.Duration
+
+	// Logger is the MANDATORY logger to use.
+	Logger Logger
+
+	// PLR is the OPTIONAL extra packet loss rate to apply to the packet.
+	PLR float64
+
+	// ServerIPAddress is the MANDATORY server endpoint IP address.
+	ServerIPAddress string
+
+	// ServerPort is the MANDATORY server endpoint port.
+	ServerPort uint16
+}
+
+var _ DPIRule = &DPIThrottleTrafficForTCPEndpoint{}
+
+// Filter implements DPIRule
+func (r *DPIThrottleTrafficForTCPEndpoint) Filter(
+	direction DPIDirection, packet *DissectedPacket) (*DPIPolicy, bool) {
+	// short circuit for the return path
+	if direction != DPIDirectionClientToServer {
+		return nil, false
+	}
+
+	// make sure the packet is TCP and for the proper endpoint
+	if !packet.MatchesDestination(layers.IPProtocolTCP, r.ServerIPAddress, r.ServerPort) {
+		return nil, false
+	}
+
+	r.Logger.Infof(
+		"netem: dpi: throttling flow %s:%d %s:%d/%s because the endpoint is filtered",
+		packet.SourceIPAddress(),
+		packet.SourcePort(),
+		packet.DestinationIPAddress(),
+		packet.DestinationPort(),
+		packet.TransportProtocol(),
 	)
 	policy := &DPIPolicy{
 		Delay:   r.Delay,


### PR DESCRIPTION
We need this feature to write test for StreamAllContext, which in turn is one of the TODOs referenced by https://github.com/ooni/probe/issues/2654.